### PR TITLE
Add sample stretching and pitch control compensation.

### DIFF
--- a/include/private/meta/sampler.h
+++ b/include/private/meta/sampler.h
@@ -37,7 +37,22 @@ namespace lsp
             static constexpr float SAMPLE_PITCH_MAX         = 24.0f;    // Maximum pitch (st)
             static constexpr float SAMPLE_PITCH_DFL         = 0.0f;     // Pitch (st)
             static constexpr float SAMPLE_PITCH_STEP        = 0.01f;    // Pitch step (st)
-                                                                    //
+                                                                        
+            static constexpr const float SAMPLE_STRETCH_MIN           = -30.0f;   // Maximum stretch (sec)
+            static constexpr const float SAMPLE_STRETCH_MAX           = 30.0f;    // Maximum stretch (sec)
+            static constexpr const float SAMPLE_STRETCH_DFL           = 0.0f;     // Stretch (sec)
+            static constexpr const float SAMPLE_STRETCH_STEP          = 0.01f;    // Stretch step (sec)
+            
+            static constexpr const float SAMPLE_STRETCH_CHUNK_MIN     = 4.0f;     // Minimum stretch chunk (bar)
+            static constexpr const float SAMPLE_STRETCH_CHUNK_MAX     = 32.0f;    // Maximum stretch chunk (bar)
+            static constexpr const float SAMPLE_STRETCH_CHUNK_DFL     = 9.0f;     // Stretch chunk (bar)
+            static constexpr const float SAMPLE_STRETCH_CHUNK_STEP    = 0.1f;     // Stretch chunk step (bar)
+
+            static constexpr const float SAMPLE_STRETCH_FADE_MIN     = 0.0f;      // Minimum stretch chunk (bar)
+            static constexpr const float SAMPLE_STRETCH_FADE_MAX     = 100.0f;    // Maximum stretch chunk (bar)
+            static constexpr const float SAMPLE_STRETCH_FADE_DFL     = 100.0f;    // Stretch chunk (bar)
+            static constexpr const float SAMPLE_STRETCH_FADE_STEP    = 0.1f;      // Stretch chunk step (bar)
+                                                                       
             static constexpr float SAMPLE_LENGTH_MIN        = 0.0f;     // Minimum length (ms)
             static constexpr float SAMPLE_LENGTH_MAX        = 64000.0f; // Maximum sample length (ms)
             static constexpr float SAMPLE_LENGTH_DFL        = 0.0f;     // Sample length (ms)
@@ -76,6 +91,7 @@ namespace lsp
             static constexpr size_t BUFFER_SIZE             = 4096;     // Size of temporary buffer
 
             static constexpr size_t INSTRUMENTS_MAX         = 64;       // Maximum supported instruments
+
         };
 
         // Different samplers

--- a/include/private/plugins/sampler_kernel.h
+++ b/include/private/plugins/sampler_kernel.h
@@ -87,11 +87,17 @@ namespace lsp
                     bool                bSync;                                          // Sync flag
                     float               fVelocity;                                      // Velocity
                     float               fPitch;                                         // Pitch (st)
+                    float               fStretch;                                       // Stretch (sec)
+                    float               fStretchStart;                                  // Stretch start (ms)
+                    float               fStretchEnd;                                    // Stretch end (ms)
+                    float               fStretchChunk;                                  // Stretch chunk (bar)
+                    float               fStretchFade;                                   // Stretch fade
                     float               fHeadCut;                                       // Head cut (ms)
                     float               fTailCut;                                       // Tail cut (ms)
                     float               fFadeIn;                                        // Fade In (ms)
                     float               fFadeOut;                                       // Fade Out (ms)
                     bool                bReverse;                                       // Reverse sample
+                    bool                bCompensate;                                    // Compensate time 
                     float               fPreDelay;                                      // Pre-delay
                     float               fMakeup;                                        // Makeup gain
                     float               fGains[meta::sampler_metadata::TRACKS_MAX];     // List of gain values
@@ -101,6 +107,11 @@ namespace lsp
 
                     plug::IPort        *pFile;                                          // Audio file port
                     plug::IPort        *pPitch;                                         // Pitch
+                    plug::IPort        *pStretch;                                       // Stretch
+                    plug::IPort        *pStretchStart;                                  // Stretch start
+                    plug::IPort        *pStretchEnd;                                    // Stretch end
+                    plug::IPort        *pStretchChunk;                                  // Stretch chunk
+                    plug::IPort        *pStretchFade;                                   // Stretch fade
                     plug::IPort        *pHeadCut;                                       // Head cut
                     plug::IPort        *pTailCut;                                       // Tail cut
                     plug::IPort        *pFadeIn;                                        // Fade in length
@@ -110,6 +121,7 @@ namespace lsp
                     plug::IPort        *pPreDelay;                                      // Pre-delay
                     plug::IPort        *pListen;                                        // Listen trigger
                     plug::IPort        *pReverse;                                       // Reverse sample
+                    plug::IPort        *pCompensate;                                    // Compensate
                     plug::IPort        *pGains[meta::sampler_metadata::TRACKS_MAX];     // List of gain ports
                     plug::IPort        *pLength;                                        // Length of the file
                     plug::IPort        *pStatus;                                        // Status of the file

--- a/res/main/ui/sampling/multiple.xml
+++ b/res/main/ui/sampling/multiple.xml
@@ -97,6 +97,11 @@
 							width.min="320"
 							height.min="160"
 							clipboard.pitch="pi${idx}"
+							clipboard.stretch="st${idx}"
+							clipboard.stretch_start="ss${idx}"
+							clipboard.stretch_end="se${idx}"
+							clipboard.stretch_chunk="sc${idx}"
+							clipboard.stretch_fade="sx${idx}"
 							clipboard.head_cut="hc${idx}"
 							clipboard.tail_cut="tc${idx}"
 							clipboard.fade_in="fi${idx}"
@@ -104,13 +109,37 @@
 							clipboard.makeup="mk${idx}"
 							clipboard.predelay="pd${idx}"/>
 
-						<grid rows="3" cols="17" bg.color="bg" hspacing="2">
+						<grid rows="3" cols="29" bg.color="bg" hspacing="2">
 							<ui:with width.min="50">
 							<label text="labels.sedit.reverse" bg.color="bg_schema" padding="6"/>
 							<cell rows="3">
 								<vsep bg.color="bg"/>
 							</cell>
 							<label text="labels.sedit.pitch" bg.color="bg_schema" padding="6"/>
+							<cell rows="3">
+								<vsep bg.color="bg"/>
+							</cell>
+							<label text="labels.sedit.compensate" bg.color="bg_schema" padding="6"/>
+							<cell rows="3">
+								<vsep bg.color="bg"/>
+							</cell>
+							<label text="labels.sedit.stretch" bg.color="bg_schema" padding="6"/>
+							<cell rows="3">
+								<vsep bg.color="bg"/>
+							</cell>
+							<label text="labels.sedit.stretch_start" bg.color="bg_schema" padding="6"/>
+							<cell rows="3">
+								<vsep bg.color="bg"/>
+							</cell>
+							<label text="labels.sedit.stretch_end" bg.color="bg_schema" padding="6"/>
+							<cell rows="3">
+								<vsep bg.color="bg"/>
+							</cell>
+							<label text="labels.sedit.stretch_chunk" bg.color="bg_schema" padding="6"/>
+							<cell rows="3">
+								<vsep bg.color="bg"/>
+							</cell>
+							<label text="labels.sedit.stretch_fade" bg.color="bg_schema" padding="6"/>
 							<cell rows="3">
 								<vsep bg.color="bg"/>
 							</cell>
@@ -151,6 +180,18 @@
 
 							<ui:with size="20" bg.color="bg_schema" pad="6" pad.t="0">
 							<knob id="pi${idx}" />
+							<cell rows="2">
+								<vbox bg.color="bg_schema">
+									<button id="pc${idx}" size="32"/>
+									<label pad.b="6"/>
+									<label pad.b="6"/>
+								</vbox>
+							</cell>
+							<knob id="st${idx}" />
+							<knob id="ss${idx}" />
+							<knob id="se${idx}" />
+							<knob id="sc${idx}" />
+              <knob id="sx${idx}" />
 							<knob id="hc${idx}" />
 							<knob id="tc${idx}" />
 							<knob id="fi${idx}" scolor="fade_in" />
@@ -166,6 +207,11 @@
 								</vbox>
 							</cell>
 							<value id="pi${idx}" bg.color="bg_schema" pad.b="6"/>
+							<value id="st${idx}" bg.color="bg_schema" pad.b="6"/>
+							<value id="ss${idx}" bg.color="bg_schema" pad.b="6"/>
+							<value id="se${idx}" bg.color="bg_schema" pad.b="6"/>
+							<value id="sc${idx}" bg.color="bg_schema" pad.b="6"/>
+							<value id="sx${idx}" bg.color="bg_schema" pad.b="6"/>
 							<value id="hc${idx}" bg.color="bg_schema" pad.b="6"/>
 							<value id="tc${idx}" bg.color="bg_schema" pad.b="6"/>
 							<value id="fi${idx}" bg.color="bg_schema" pad.b="6"/>

--- a/res/main/ui/sampling/single/mono.xml
+++ b/res/main/ui/sampling/single/mono.xml
@@ -75,6 +75,8 @@
 					width.min="320"
 					height.min="160"
 					clipboard.pitch="pi[ssel]"
+					clipboard.stretch="st${idx}"
+					clipboard.stretch_chunk="sc${idx}"
 					clipboard.head_cut="hc[ssel]"
 					clipboard.tail_cut="tc[ssel]"
 					clipboard.fade_in="fi[ssel]"
@@ -82,13 +84,25 @@
 					clipboard.makeup="mk[ssel]"
 					clipboard.predelay="pd[ssel]"/>
 
-				<grid rows="3" cols="17" bg.color="bg" hspacing="2">
+				<grid rows="3" cols="23" bg.color="bg" hspacing="2">
 					<ui:with width.min="50">
 					<label text="labels.sedit.reverse" bg.color="bg_schema" padding="6"/>
 					<cell rows="3">
 						<vsep bg.color="bg"/>
 					</cell>
 					<label text="labels.sedit.pitch" bg.color="bg_schema" padding="6"/>
+					<cell rows="3">
+						<vsep bg.color="bg"/>
+					</cell>
+					<label text="labels.sedit.compensate" bg.color="bg_schema" padding="6"/>
+					<cell rows="3">
+						<vsep bg.color="bg"/>
+					</cell>
+					<label text="labels.sedit.stretch" bg.color="bg_schema" padding="6"/>
+					<cell rows="3">
+						<vsep bg.color="bg"/>
+					</cell>
+					<label text="labels.sedit.stretch_chunk" bg.color="bg_schema" padding="6"/>
 					<cell rows="3">
 						<vsep bg.color="bg"/>
 					</cell>
@@ -129,6 +143,15 @@
 
 					<ui:with size="20" bg.color="bg_schema" pad="6" pad.t="0">
 					<knob id="pi[ssel]" />
+					<cell rows="2">
+						<vbox bg.color="bg_schema">
+							<button id="pc${idx}" size="32"/>
+							<label pad.b="6"/>
+							<label pad.b="6"/>
+						</vbox>
+					</cell>
+					<knob id="st${idx}" />
+					<knob id="sc${idx}" />
 					<knob id="hc[ssel]" />
 					<knob id="tc[ssel]" />
 					<knob id="fi[ssel]" scolor="fade_in" />
@@ -144,6 +167,8 @@
 						</vbox>
 					</cell>
 					<value id="pi[ssel]" bg.color="bg_schema" pad.b="6"/>
+					<value id="st${idx}" bg.color="bg_schema" pad.b="6"/>
+					<value id="sc${idx}" bg.color="bg_schema" pad.b="6"/>
 					<value id="hc[ssel]" bg.color="bg_schema" pad.b="6"/>
 					<value id="tc[ssel]" bg.color="bg_schema" pad.b="6"/>
 					<value id="fi[ssel]" bg.color="bg_schema" pad.b="6"/>

--- a/res/main/ui/sampling/single/stereo.xml
+++ b/res/main/ui/sampling/single/stereo.xml
@@ -75,6 +75,8 @@
 					width.min="320"
 					height.min="160"
 					clipboard.pitch="pi[ssel]"
+					clipboard.stretch="st${idx}"
+					clipboard.stretch_chunk="sc${idx}"
 					clipboard.head_cut="hc[ssel]"
 					clipboard.tail_cut="tc[ssel]"
 					clipboard.fade_in="fi[ssel]"
@@ -82,13 +84,25 @@
 					clipboard.makeup="mk[ssel]"
 					clipboard.predelay="pd[ssel]"/>
 
-				<grid rows="3" cols="17" bg.color="bg" hspacing="2">
+				<grid rows="3" cols="23" bg.color="bg" hspacing="2">
 					<ui:with width.min="50">
 					<label text="labels.sedit.reverse" bg.color="bg_schema" padding="6"/>
 					<cell rows="3">
 						<vsep bg.color="bg"/>
 					</cell>
 					<label text="labels.sedit.pitch" bg.color="bg_schema" padding="6"/>
+					<cell rows="3">
+						<vsep bg.color="bg"/>
+					</cell>
+					<label text="labels.sedit.compensate" bg.color="bg_schema" padding="6"/>
+					<cell rows="3">
+						<vsep bg.color="bg"/>
+					</cell>
+					<label text="labels.sedit.stretch" bg.color="bg_schema" padding="6"/>
+					<cell rows="3">
+						<vsep bg.color="bg"/>
+					</cell>
+					<label text="labels.sedit.stretch_chunk" bg.color="bg_schema" padding="6"/>
 					<cell rows="3">
 						<vsep bg.color="bg"/>
 					</cell>
@@ -129,6 +143,15 @@
 
 					<ui:with size="20" bg.color="bg_schema" pad="6" pad.t="0">
 					<knob id="pi[ssel]" />
+					<cell rows="2">
+						<vbox bg.color="bg_schema">
+							<button id="pc${idx}" size="32"/>
+							<label pad.b="6"/>
+							<label pad.b="6"/>
+						</vbox>
+					</cell>
+					<knob id="st${idx}" />
+					<knob id="sc${idx}" />
 					<knob id="hc[ssel]" />
 					<knob id="tc[ssel]" />
 					<knob id="fi[ssel]" scolor="fade_in" />
@@ -144,6 +167,8 @@
 						</vbox>
 					</cell>
 					<value id="pi[ssel]" bg.color="bg_schema" pad.b="6"/>
+					<value id="st${idx}" bg.color="bg_schema" pad.b="6"/>
+					<value id="sc${idx}" bg.color="bg_schema" pad.b="6"/>
 					<value id="hc[ssel]" bg.color="bg_schema" pad.b="6"/>
 					<value id="tc[ssel]" bg.color="bg_schema" pad.b="6"/>
 					<value id="fi[ssel]" bg.color="bg_schema" pad.b="6"/>

--- a/src/main/meta/sampler.cpp
+++ b/src/main/meta/sampler.cpp
@@ -178,6 +178,11 @@ namespace lsp
         #define S_SAMPLE_FILE(gain)        \
             PATH("sf", "Sample file"), \
             CONTROL("pi", "Sample pitch", U_SEMITONES, sampler_metadata::SAMPLE_PITCH), \
+            CONTROL("st", "Sample stretch", U_SEC, sampler_metadata::SAMPLE_STRETCH), \
+            CONTROL("ss", "Sample stretch start", U_MSEC, sampler_metadata::SAMPLE_LENGTH), \
+            CONTROL("se", "Sample stretch end", U_MSEC, sampler_metadata::SAMPLE_LENGTH), \
+            CONTROL("sc", "Sample stretch chunk", U_BAR, sampler_metadata::SAMPLE_STRETCH_CHUNK), \
+            CONTROL("sx", "Sample stretch fade", U_PERCENT, sampler_metadata::SAMPLE_STRETCH_FADE), \
             CONTROL("hc", "Sample head cut", U_MSEC, sampler_metadata::SAMPLE_LENGTH), \
             CONTROL("tc", "Sample tail cut", U_MSEC, sampler_metadata::SAMPLE_LENGTH), \
             CONTROL("fi", "Sample fade in", U_MSEC, sampler_metadata::SAMPLE_LENGTH), \
@@ -189,6 +194,7 @@ namespace lsp
             SWITCH("on", "Sample enabled", 1.0f), \
             TRIGGER("ls", "Sample listen"), \
             SWITCH("rs", "Sample reverse", 0.0f), \
+            SWITCH("pc", "Sample auto-compensate", 0.0f), \
             gain, \
             BLINK("ac", "Sample activity"), \
             BLINK("no", "Sample note on event"), \

--- a/src/main/ui/sampler.cpp
+++ b/src/main/ui/sampler.cpp
@@ -713,6 +713,11 @@ namespace lsp
 
             set_float_value(1.0f, "on_%d_%d", id, jd);                      // enabled
             set_float_value(meta::sampler_metadata::SAMPLE_PITCH_DFL, "pi_%d_%d", id, jd);      // sample pitch
+            set_float_value(meta::sampler_metadata::SAMPLE_STRETCH_DFL, "st_%d_%d", id, jd);    // stretch
+            set_float_value(meta::sampler_metadata::SAMPLE_LENGTH_DFL, "ss_%d_%d", id, jd);     // stretch
+            set_float_value(meta::sampler_metadata::SAMPLE_LENGTH_DFL, "se_%d_%d", id, jd);     // stretch
+            set_float_value(meta::sampler_metadata::SAMPLE_STRETCH_CHUNK_DFL, "sc_%d_%d", id, jd);    // stretch
+            set_float_value(meta::sampler_metadata::SAMPLE_STRETCH_FADE_DFL, "sx_%d_%d", id, jd);          // stretch
             set_float_value(meta::sampler_metadata::SAMPLE_LENGTH_DFL, "hc_%d_%d", id, jd);     // head cut
             set_float_value(meta::sampler_metadata::SAMPLE_LENGTH_DFL, "tc_%d_%d", id, jd);     // tail cut
             set_float_value(meta::sampler_metadata::SAMPLE_LENGTH_DFL, "fi_%d_%d", id, jd);     // fade in


### PR DESCRIPTION
This adds a `Stretch`, `Start`, `End`, `Chunk size` and `Fade length` knobs plus a `Compensate` button.

![Screenshot_20221011_204927](https://user-images.githubusercontent.com/8728677/195165830-90bffe4b-2498-4da1-ad69-33d697e72b19.png)


Uses the function from [lsp-dsp-units/PR-3](https://github.com/lsp-plugins/lsp-dsp-units/pull/3) to apply time stretching